### PR TITLE
Remove deprecated property usage

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -114,7 +114,7 @@ function putObject (context, params, callback) {
     context.logger.info('received put resonse for', params.Bucket, params.Key)
     let headers = result.headers
     return {
-      Location: `https://${result.req._headers.host}${result.req.path}`,
+      Location: `https://${result.req.getHeaders().host}${result.req.path}`,
       Expiration: headers['x-amz-expiration'],
       Etag: headers['etag'],
       ServerSideEncryption: headers['x-amz-server-side​-encryption'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-thin-s3",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "description": "aws thin S3 client",
   "main": "lib/s3.js",
   "repository": "git@github.nike.com:ngp/aws-thin-ses.git",
@@ -17,7 +17,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "scripts": {
     "style": "standard \"index.js\" \"lib/**/*.js\" | snazzy",


### PR DESCRIPTION
This requires a major version change because it will not support older versions of node that do not have the `OutgoingMessage.prototype.getHeaders` method.